### PR TITLE
fix: add missing semicolon to orgMembers mock data

### DIFF
--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -35,7 +35,7 @@ const initialMarkets: Market[] = [
 const orgMembers: OrgMember[] = [
     { id: 'user-1', name: 'Admin User', email: 'admin@marketmate.com', role: 'Owner' },
     { id: 'user-2', name: 'Jane Orga', email: 'jane.orga@marketmate.com', role: 'Admin' }
-]
+];
 
 const initialArticles: Article[] = [
   { id: 1, description: "Vintage Denim Jacket", price: 45.00 },


### PR DESCRIPTION
## Summary
- add missing semicolon to orgMembers mock data definition

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aafef32bb483228d00df3ce77a0d7f