### PR TITLE
Mock-Daten über Umgebungsvariable steuerbar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Environment variables for MarketMate
+# Set to 'true' to use local mock data
+USE_MOCK_DATA=true
+

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ next-env.d.ts
 
 .genkit/*
 .env*
+!.env.example
 
 # firebase
 firebase-debug.log

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -7,9 +7,8 @@
 import { getMockArticles, getMockMarkets, getMockOrgMembers } from './mock-data';
 import type { Article, Market, OrgMember } from './types';
 
-// This is our feature flag. Set to `true` to use local mock data.
-// In a real application, this would be an environment variable like `process.env.USE_MOCK_DATA === 'true'`.
-const USE_MOCK_DATA = true;
+// This is our feature flag. Set the `USE_MOCK_DATA` environment variable to 'true' to use local mock data.
+const USE_MOCK_DATA = process.env.USE_MOCK_DATA === 'true';
 
 export async function getMarkets(): Promise<Market[]> {
   if (USE_MOCK_DATA) {


### PR DESCRIPTION
## Summary
- Steuere Datenebene über die Umgebungsvariable `USE_MOCK_DATA`
- Dokumentiere `USE_MOCK_DATA` in `.env.example` und ermögliche Tracking der Datei

## Testing
- `npm run lint` *(konfiguration erforderlich, läuft interaktiv)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aafefb9d60832291a2826261f98e43