### PR TITLE
Handle errors when fetching and adding articles

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -42,13 +42,21 @@ export default function DashboardPage() {
   React.useEffect(() => {
     // Fetch articles on component mount
     const fetchArticles = async () => {
+      try {
         const articlesData = await getArticles(SELLER_NUMBER);
         setArticles(articlesData);
+      } catch (error) {
+        toast({
+          variant: "destructive",
+          title: "Error",
+          description: "Failed to load articles.",
+        });
+      }
     };
     if (role === 'seller') {
       fetchArticles();
     }
-  }, [role]);
+  }, [role, toast]);
 
 
   // Quick function to format names
@@ -65,12 +73,21 @@ export default function DashboardPage() {
         return;
     }
     const formData = new FormData(e.currentTarget);
+    const price = Number(formData.get('price'));
+    if (!Number.isFinite(price)) {
+      toast({
+        variant: "destructive",
+        title: "Invalid Price",
+        description: "Please enter a valid price.",
+      });
+      return;
+    }
     const newArticle: Article = {
       id: Math.max(0, ...articles.map(a => a.id)) + 1,
       description: formData.get('description') as string,
-      price: parseFloat(formData.get('price') as string),
+      price,
     };
-    setArticles([...articles, newArticle]);
+    setArticles(prev => [...prev, newArticle]);
     toast({
       title: "Article Added",
       description: `"${newArticle.description}" has been added to your list.`,


### PR DESCRIPTION
## Summary
- Add toast-based error handling around `getArticles` in dashboard article fetch
- Validate and parse article price input and update state using functional setter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for interactive ESLint setup)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68aaff33416c8322a340b6ea139a3d82