### PR TITLE
Avoid trailing query marker when no params

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -49,7 +49,8 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     if (org) params.set('org', org);
     if (market) params.set('market', market);
     if (role) params.set('role', role);
-    return `${path}?${params.toString()}`;
+    const query = params.toString();
+    return query ? `${path}?${query}` : path;
   }
 
   return (


### PR DESCRIPTION
## Summary
- Only append query string in `linkWithParams` when params exist

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: requires interactive setup)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aaff537a248322beefb9a35558d031