### PR TITLE
chore: enforce lint and type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run build

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,14 @@
 import type {NextConfig} from 'next';
 
+const isDev = process.env.NODE_ENV === 'development';
+
 const nextConfig: NextConfig = {
   /* config options here */
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: isDev,
   },
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: isDev,
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Summary
- only ignore lint and type errors during development
- run lint, typecheck, and build in CI

## Testing
- `npm run lint` *(fails: requires initial ESLint configuration)*
- `npm run typecheck`
- `npm run build` *(fails: useSearchParams() should be wrapped in a suspense boundary at page "/dashboard/admin"*)

------
https://chatgpt.com/codex/tasks/task_e_68aaff68863c83229ba99323ee0db22d